### PR TITLE
Fixed time display in meeting reports data table

### DIFF
--- a/app/views/admin/reports_meetings.html.erb
+++ b/app/views/admin/reports_meetings.html.erb
@@ -19,8 +19,8 @@
             <tr>
             <td><%= reports_meeting.title %></td>
             <td><%= reports_meeting.agenda %></td>
-            <td><%= reports_meeting.start_time %></td>
-            <td><%= reports_meeting.end_time %></td>
+            <td><%= reports_meeting.start_time.strftime("%m/%d/%Y %l:%M %p") %></td>
+            <td><%= reports_meeting.end_time.strftime("%m/%d/%Y %l:%M %p") %></td>
             <td><%= reports_meeting.private %></td>
             <td><%= reports_meeting.room_id %></td>
             <td><%= reports_meeting.employee_id %></td>


### PR DESCRIPTION
Added strftime to start_time and end_time entries in the meetings report table.
