### PR TITLE
updated no over lap method in ap contrlr to use association instead o…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,8 +9,7 @@ class ApplicationController < ActionController::Base
   end
 
   def no_meeting_overlap? (requested_meeting)
-    employee_meetings = Meeting.where(employee_id: current_employee.id)
-    employee_meetings += EmployeeMeeting.where(employee_id: current_employee.id).map{ |em| em.meeting }
+    employee_meetings = current_employee.confirmed_meetings
     employee_meetings.each do |meeting|
       if requested_meeting.start_time < meeting.end_time && requested_meeting.start_time >= meeting.start_time ||
          requested_meeting.end_time > meeting.start_time && requested_meeting.start_time <= meeting.start_time


### PR DESCRIPTION
- refactored `no_meeting_overlap?` to use `confirmed_meetings` association from employee model
