### PR TITLE
added route for invites show page for real

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,8 @@ Rails.application.routes.draw do
 
     resources :rooms
     resources :companies, except: :index
-    get 'admin/invitations/show', to: "invitations#show"
+    get 'admin/invitations/show', to: "invitations#show", as: 'invitations'
+    post 'admin/invitations/show', to: "invitations#create"
     delete 'invitations/:id', to: "invitations#destroy", as: 'invitation'
     resources :meetings
 


### PR DESCRIPTION
Added a "invitations" path to routes that takes 'admin/invitations/show' to 'invitations#show' as 'invitations'. This shouldn't conflict with the routes for invites already set up.

@Graciexia @mlgiardina please take a look to make sure this doesn't interfere with your stuff.
